### PR TITLE
Automatically add user id on send_msg route

### DIFF
--- a/tinder_api.py
+++ b/tinder_api.py
@@ -161,7 +161,7 @@ def get_person(id):
 def send_msg(match_id, msg):
     try:
         my_id = get_self()['_id']
-        url = config.host + '/user/matches/%s' % match_id + my_id
+        url = config.host + '/user/matches/%s%s' % (match_id, my_id)
         r = requests.post(url, headers=headers,
                           data=json.dumps({"message": msg}))
         return r.json()

--- a/tinder_api.py
+++ b/tinder_api.py
@@ -160,7 +160,8 @@ def get_person(id):
 
 def send_msg(match_id, msg):
     try:
-        url = config.host + '/user/matches/%s' % match_id
+        my_id = get_self()['_id']
+        url = config.host + '/user/matches/%s' % match_id + my_id
         r = requests.post(url, headers=headers,
                           data=json.dumps({"message": msg}))
         return r.json()


### PR DESCRIPTION
The way the /matches/_id route is written on README seems that you only need to pass the target's id but you also need to pass your id with it.