### PR TITLE
Add endpoint for reading activity feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Note: All curls must be sent with the headers as well (the only exception is tha
          <td>POST</td>
       </tr>
       <tr>
+         <td>/v1/activity/feed?direction=past&eventTypes=1023</td>
+         <td>Get activity feed, including old and updated bios for comparison</td>
+         <td>{}</td>
+         <td>GET</td>
+      <tr>
          <td>/instagram/authorize</td>
          <td>Auth Instagram</td>
          <td>{}</td>


### PR DESCRIPTION
It appears that the eventTypes may be used to pull specifically changed photos or changed bios individually. The Android app uses 1023 which I would presume pulls everything we'd be interested in seeing.

direction=past doesn't immediately make sense unless tinder's implemented time travel