### PR TITLE
Fix phone auth api login

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,19 @@ Note: All curls must be sent with the headers as well (the only exception is tha
       <tr>
        <td>/v2/auth/sms/send?auth_type=sms</td>
        <td>Part 1 of SMS authentication (two-factor)</td>
-       <td>{'phone_number': INSERT_HERE}</td>
+       <td>{'phone_number': string}</td>
 		 <td>POST</td>
 	  </tr>
       <tr>
-		 <td>/v2/auth/login/sms</td>
+		 <td>/v2/auth/sms/validate?auth_type=sms</td>
 		 <td>Part 2 of SMS authentication (two-factor)</td>
-		 <td>{'otp_code': INSERT_HERE, 'phone_number': INSERT_HERE }</td>
+		 <td>{'otp_code': string, 'phone_number': string }</td>
 		 <td>POST</td>
 	  </tr>
      	<tr>
 		 <td>/v2/auth/login/sms</td>
 		 <td>Part 3 of SMS authentication (two-factor)</td>
-		 <td>{'refresh_token': INSERT_HERE}</td>
+		 <td>{'refresh_token': string}</td>
 		 <td>POST</td>
 	  </tr>
       <tr>

--- a/README.md
+++ b/README.md
@@ -62,10 +62,22 @@ Note: All curls must be sent with the headers as well (the only exception is tha
          <td>{'facebook_token': INSERT_HERE, 'facebook_id': INSERT_HERE}</td>
          <td>POST</td>
       </tr>
-	  <tr>
-		 <td>/auth/login/accountkit</td>
-		 <td>For SMS authentication (two-factor)</td>
-		 <td>{'token': INSERT_HERE, 'id': INSERT_HERE, 'client_version':'9.0.1'}</td>
+      <tr>
+       <td>/v2/auth/sms/send?auth_type=sms</td>
+       <td>Part 1 of SMS authentication (two-factor)</td>
+       <td>{'phone_number': INSERT_HERE}</td>
+		 <td>POST</td>
+	  </tr>
+      <tr>
+		 <td>/v2/auth/login/sms</td>
+		 <td>Part 2 of SMS authentication (two-factor)</td>
+		 <td>{'otp_code': INSERT_HERE, 'phone_number': INSERT_HERE }</td>
+		 <td>POST</td>
+	  </tr>
+     	<tr>
+		 <td>/v2/auth/login/sms</td>
+		 <td>Part 3 of SMS authentication (two-factor)</td>
+		 <td>{'refresh_token': INSERT_HERE}</td>
 		 <td>POST</td>
 	  </tr>
       <tr>

--- a/phone_auth_token.py
+++ b/phone_auth_token.py
@@ -1,40 +1,41 @@
 import requests
 import json
 
-CODE_REQUEST_URL = "https://graph.accountkit.com/v1.2/start_login?access_token=AA%7C464891386855067%7Cd1891abb4b0bcdfa0580d9b839f4a522&credentials_type=phone_number&fb_app_events_enabled=1&fields=privacy_policy%2Cterms_of_service&locale=fr_FR&phone_number=#placeholder&response_type=token&sdk=ios"
-CODE_VALIDATE_URL = "https://graph.accountkit.com/v1.2/confirm_login?access_token=AA%7C464891386855067%7Cd1891abb4b0bcdfa0580d9b839f4a522&confirmation_code=#confirmation_code&credentials_type=phone_number&fb_app_events_enabled=1&fields=privacy_policy%2Cterms_of_service&locale=fr_FR&login_request_code=#request_code&phone_number=#phone_number&response_type=token&sdk=ios"
-TOKEN_URL = "https://api.gotinder.com/v2/auth/login/accountkit"
+CODE_REQUEST_URL = "https://api.gotinder.com/v2/auth/sms/send?auth_type=sms"
+CODE_VALIDATE_URL = "https://api.gotinder.com/v2/auth/sms/validate?auth_type=sms"
+TOKEN_URL = "https://api.gotinder.com/v2/auth/login/sms"
 
-HEADERS = {'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 AKiOSSDK/4.29.0'}
+HEADERS = {'user-agent': 'Tinder/11.4.0 (iPhone; iOS 12.4.1; Scale/2.00)', 'content-type': 'application/json'}
 
-def sendCode(number):
-    URL = CODE_REQUEST_URL.replace("#placeholder", number)
-    r = requests.post(URL, headers=HEADERS, verify=False)
+def send_otp_code(phone_number):
+    data = {'phone_number': phone_number}
+    r = requests.post(CODE_REQUEST_URL, headers=HEADERS, data=json.dumps(data), verify=False)
     print(r.url)
     response = r.json()
-    if(response.get("login_request_code") == None):
+    if(response.get("data")['sms_sent'] == False):
         return False
     else:
-        return response["login_request_code"]
+        return True
 
-def getToken(number, code, req_code):
-    VALIDATE_URL = CODE_VALIDATE_URL.replace("#confirmation_code", code)
-    VALIDATE_URL = VALIDATE_URL.replace("#phone_number", number)
-    VALIDATE_URL = VALIDATE_URL.replace("#request_code", req_code)
-    r_validate = requests.post(VALIDATE_URL, headers=HEADERS, verify=False)
-    validate_response = r_validate.json()
-    access_token = validate_response["access_token"]
-    access_id = validate_response["id"]
-    GetToken_content = json.dumps({'token':access_token, 'id':access_id, "client_version":"9.0.1"})
-    GetToken_headers = {'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 AKiOSSDK/4.29.0', 'Content-Type':'application/json'}
-    r_GetToken = requests.post(TOKEN_URL, data=GetToken_content, headers=GetToken_headers, verify=False)
-    token_response = r_GetToken.json()
-    if(token_response["data"].get("api_token") == None):
-        return token_response
+def get_refresh_token(otp_code, phone_number):
+    data = {'otp_code': otp_code, 'phone_number': phone_number}
+    r = requests.post(CODE_VALIDATE_URL, headers=HEADERS, data=json.dumps(data), verify=False)
+    print(r.url)
+    response = r.json()
+    if(response.get("data")["validated"] == False):
+        return False
     else:
-        return token_response["data"]["api_token"]
+        return response.get("data")["refresh_token"]
+    
+def get_api_token(refresh_token):
+    data = {'refresh_token': refresh_token }
+    r = requests.post(TOKEN_URL, headers=HEADERS, data=json.dumps(data), verify=False)
+    print(r.url)
+    response = r.json()
+    return response.get("data")["api_token"]
 
-phone_number = input("Please enter your phone number under the international format (country code + number)")
-log_code = sendCode(phone_number)
-sms_code = input("Please enter the code you've received by sms")
-print("Here is your Tinder token :" + str(getToken(phone_number, sms_code, log_code)))
+phone_number = input("Please enter your phone number under the international format (country code + number): ")
+log_code = send_otp_code(phone_number)
+otp_code = input("Please enter the code you've received by sms: ")
+refresh_token = get_refresh_token(otp_code, phone_number)
+print("Here is your Tinder token: " + str(get_api_token(refresh_token)))


### PR DESCRIPTION
Tinder moved away from account kit login - being deprecated later next year I believe

Fixed the README and phone_auth_token.py for these new changes

Fixes #87 and #89 