### PR TITLE
Updated status codes table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ Note: All curls must be sent with the headers as well (the only exception is tha
 			<td>The server didn't find the resource you tried to access.</td>
 		</tr>
 		<tr>
+			<td>429</td>
+			<td>You're sending requests to the server too quickly</td>
+		</tr>
+		<tr>
 			<td>503</td>
 			<td>Back-end server is at capacity.</td>
 		</tr>


### PR DESCRIPTION
Added 429 code that can be received from the `get_auth_token` method of the tinder api